### PR TITLE
resolve merge conflict: apply PR #8 fixes to current main

### DIFF
--- a/scripts/SetupLinux4Delphi.sh
+++ b/scripts/SetupLinux4Delphi.sh
@@ -62,7 +62,8 @@ while [[ $# -gt 0 ]]; do
       echo "  11.2               = Alexandria 11.2"
       echo "  11.1               = Alexandria 11.1"
       echo "  11.0               = Alexandria 11.0"
-      echo "  21.0, 10.4.1       = Sydney 10.4.1"
+      echo "  21.0, 10.4, 10.4.2 = Sydney 10.4.2"
+      echo "  10.4.1             = Sydney 10.4.1"
       echo "  10.4.0             = Sydney 10.4.0"
       echo "  20.0, 10.3, 10.3.3 = Rio 10.3.3"
       echo "  10.3.2             = Rio 10.3.2"
@@ -123,7 +124,7 @@ case "$PARAM" in
         COMPILER="22.0"
         PRODUCT="11.3"
         RELEASE="Alexandria"
-        PASERVER_URL="https://altd.embarcadero.com/releases/studio/22.0/113/LinuxPAServer22.0.tar.gz"
+        PASERVER_URL="https://altd.embarcadero.com/releases/studio/22.0/1131/LinuxPAServer22.0.tar.gz"
     ;;
     "11.0")
         COMPILER="22.0"
@@ -144,7 +145,13 @@ case "$PARAM" in
         PASERVER_URL="https://altd.embarcadero.com/releases/studio/22.0/112/LinuxPAServer22.0.tar.gz"
     ;;  
     # Sydney
-    "10.4"|"10.4.1"|"sydney"|"21.0")
+    "10.4"|"10.4.2"|"sydney"|"21.0")
+        COMPILER="21.0"
+        PRODUCT="10.4.2"
+        RELEASE="Sydney"
+        PASERVER_URL="https://altd.embarcadero.com/releases/studio/21.0/2/PAServer/LinuxPAServer21.0.tar.gz"
+    ;;
+    "10.4.1")
         COMPILER="21.0"
         PRODUCT="10.4.1"
         RELEASE="Sydney"


### PR DESCRIPTION
- fix Alexandria 11.3 PAServer URL: /113/ -> /1131/ (build 28.0.48361.3236)
- add Sydney 10.4.2 case; update 10.4/sydney/21.0 aliases to point to 10.4.2
- preserve 10.4.1 as an explicit exact-version selector
- update help text to reflect new Sydney default

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016Pn2b7amU63zQDmgmva78Q